### PR TITLE
Enrich GO API with SetBeaconPeerPort() - issue #13

### DIFF
--- a/options.go
+++ b/options.go
@@ -66,6 +66,23 @@ func SetPort(port int) Option {
 	}
 }
 
+// SetBeaconPeerPort - Set TCP beacon peer port. The default beacon peer port depends on operating
+// but has to be considered as random.
+// Use SetBeaconPeerPort() to override the default with a well known value. 
+// Very useful to simplify firewall rules (because of randomness of default port).
+func (z *Node) SetBeaconPeerPort(port int) {
+	if z.ptr == nil {
+		panic("Node.SetBeaconPeerPort: z.ptr is null")
+	}
+	C.zyre_set_beacon_peer_port(z.ptr, C.int(port))
+}
+
+func SetBeaconPeerPort(port int) Option {
+	return func(z *Node) {
+		z.SetBeaconPeerPort(port)
+	}
+}
+
 // SetEvasiveTimeout - Set the peer evasiveness timeout, Default is 5000
 // millisecond.  This can be tuned in order to deal with expected network
 // conditions and the response time expected by the application. This is tied


### PR DESCRIPTION
Solved last year, under ZYRE issues #593 or #594, following the long debate
on ZYRE issue #323.

This function allows to have a unique well defined (non-random) firewall rule.