### PR TITLE
Problem: CI for gozyre fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs: # basic units of work in a run
       - checkout # check out source code to working directory
       - run: 
         #TODO: create own Docker container under hub.docker.com/zeromq/
-          name: Add C dependencies
+          name: Add stable dependencies
           command: |
             sudo sed -e '$s,$,\ndeb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_10/ ./,' -i /etc/apt/sources.list
             sudo curl 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/Debian_10/Release.key' > Release.key
@@ -37,12 +37,28 @@ jobs: # basic units of work in a run
       - run: go get github.com/jstemmer/go-junit-report
 
       - run:
-          name: Run unit tests
+          name: Run unit tests for stable version
           command: |
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
             go test | tee ${TEST_RESULTS}/go-test.out
 
-      - run: go build # pull and build dependencies for the project
+      - run: go build # pull and build dependencies for the projec
+
+      - run: 
+          name: Add draft dependencies
+          command: |
+            sudo apt-get remove libzyre-dev libzmq3-dev libczmq-dev libzyre2 libczmq4 libzmq5
+            sudo sed -e 's/release-stable/git-draft/' -i /etc/apt/sources.list
+            sudo curl 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/Debian_10/Release.key' > Release.key
+            sudo apt-key add - < Release.key
+            sudo apt-get update
+            sudo apt-get install libzyre-dev libzmq3-dev libczmq-dev libzyre2 libczmq4 libzmq5
+
+      - run:
+          name: Run unit tests for draft version
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+            go test -tags=draft | tee ${TEST_RESULTS}/go-test.out
 
       - save_cache: # Store cache in the /go/pkg directory
           key: v1-pkg-cache

--- a/options.go
+++ b/options.go
@@ -66,23 +66,6 @@ func SetPort(port int) Option {
 	}
 }
 
-// SetBeaconPeerPort - Set TCP beacon peer port. The default beacon peer port depends on operating
-// but has to be considered as random.
-// Use SetBeaconPeerPort() to override the default with a well known value. 
-// Very useful to simplify firewall rules (because of randomness of default port).
-func (z *Node) SetBeaconPeerPort(port int) {
-	if z.ptr == nil {
-		panic("Node.SetBeaconPeerPort: z.ptr is null")
-	}
-	C.zyre_set_beacon_peer_port(z.ptr, C.int(port))
-}
-
-func SetBeaconPeerPort(port int) Option {
-	return func(z *Node) {
-		z.SetBeaconPeerPort(port)
-	}
-}
-
 // SetEvasiveTimeout - Set the peer evasiveness timeout, Default is 5000
 // millisecond.  This can be tuned in order to deal with expected network
 // conditions and the response time expected by the application. This is tied

--- a/options_draft.go
+++ b/options_draft.go
@@ -2,6 +2,8 @@
 
 package zyre
 
+//#cgo pkg-config: libzyre
+//#include<zyre.h>
 import (
     "C"
 )

--- a/options_draft.go
+++ b/options_draft.go
@@ -1,0 +1,24 @@
+// +build draft
+
+package zyre
+
+import (
+    "C"
+)
+
+// SetBeaconPeerPort - Set TCP beacon peer port. The default beacon peer port depends on operating
+// but has to be considered as random.
+// Use SetBeaconPeerPort() to override the default with a well known value. 
+// Very useful to simplify firewall rules (because of randomness of default port).
+func (z *Node) SetBeaconPeerPort(port int) {
+	if z.ptr == nil {
+		panic("Node.SetBeaconPeerPort: z.ptr is null")
+	}
+	C.zyre_set_beacon_peer_port(z.ptr, C.int(port))
+}
+
+func SetBeaconPeerPort(port int) Option {
+	return func(z *Node) {
+		z.SetBeaconPeerPort(port)
+	}
+}


### PR DESCRIPTION
Solution: move set_beacon_port to `options_draft.go` hidden by build
tag, change CI config to install git-draft dependencies and test draft
build too

Fixes https://github.com/zeromq/gozyre/issues/16